### PR TITLE
Fix bug blocking the stream after one connection

### DIFF
--- a/server/src/ws_factory.rs
+++ b/server/src/ws_factory.rs
@@ -25,9 +25,12 @@ impl SubscriberBuilder {
         loop {
             match listener.accept().await {
                 Ok((stream, addr)) => {
-                    let mut new_subscriber =
-                        Subscriber::new(self.subtitle.clone(), self.color.clone(), addr);
-                    new_subscriber.run(stream).await;
+                    tokio::spawn({
+                        let mut new_subscriber =Subscriber::new(self.subtitle.clone(), self.color.clone(), addr);
+                        async move {
+                            new_subscriber.run(stream).await;
+                        }
+                    });
                 }
                 Err(error) => {
                     // Retry reconnect in 10 seconds


### PR DESCRIPTION
By mistake, the listener of the ws-factory was blocked for new connections after one subscriber connected.

This is a fix for that issue, that will spawn new Subscriber actors in different tokio task to attend to those new Subscribers without blocking the TcpStream.