### PR TITLE
Add tests for targeted devices functionality

### DIFF
--- a/lamarrs-utils/src/enums.rs
+++ b/lamarrs-utils/src/enums.rs
@@ -115,7 +115,7 @@ pub enum RegisterResult{
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum CloseConnectionReason{
     SubscriberRequest,
-    GatewatRequest,
+    GatewayRequest,
     Unexpected
 }
 
@@ -123,7 +123,7 @@ impl std::fmt::Display for CloseConnectionReason{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let value = match self {
             Self::SubscriberRequest=> "Subscriber Request",
-            Self::GatewatRequest=> "Gatewat Request",
+            Self::GatewayRequest=> "Gateway Request",
             Self::Unexpected=> "Unexpected",
         };
         write!(f, "{}", value)
@@ -133,12 +133,14 @@ impl std::fmt::Display for CloseConnectionReason{
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum Service{
     Subtitle,
+    Color,
 }
 
 impl std::fmt::Display for Service{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let value = match self {
             Self::Subtitle=> "Subtitle",
+            Self::Color=> "Color",
         };
         write!(f, "{}", value)
     }

--- a/lamarrs-utils/src/enums.rs
+++ b/lamarrs-utils/src/enums.rs
@@ -133,14 +133,14 @@ impl std::fmt::Display for CloseConnectionReason{
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum Service{
     Subtitle,
-    Color,
+    Color
 }
 
 impl std::fmt::Display for Service{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let value = match self {
             Self::Subtitle=> "Subtitle",
-            Self::Color=> "Color",
+            Self::Color=> "Color"
         };
         write!(f, "{}", value)
     }

--- a/server/src/subscriber.rs
+++ b/server/src/subscriber.rs
@@ -234,6 +234,16 @@ impl Subscriber {
                                 .await
                                 .unwrap();
                         }
+                        Service::Color => {
+                            self.color
+                                .send(ColorMessage::Subscribe(SusbcriptionData {
+                                    sender_id: self.id.uuid.unwrap(),
+                                    sender: self.sender.clone(),
+                                    location: self.id.location.clone().unwrap(),
+                                }))
+                                .await
+                                .unwrap();
+                        }
                     }
                 }
                 Err(_) => todo!(),

--- a/server/src/test/mod.rs
+++ b/server/src/test/mod.rs
@@ -110,3 +110,156 @@ async fn test_new_client_subscribes_to_subtitles() {
         result
     );
 }
+
+#[test_log::test(tokio::test)]
+async fn test_new_client_subscribes_to_color() {
+    let (listener, url) = start_tcp_stream().await;
+    let mut fake_client: FakeSubscriber = FakeSubscriber::new(url, RelativeLocation::Center).await;
+    let (subtitle_service, color_service) = create_services();
+    tokio::spawn(start_app(subtitle_service, color_service, listener));
+    fake_client.start().await;
+    fake_client.register().await;
+    let result = fake_client.recv().await.unwrap();
+    assert_eq!(
+        GatewayMessage::RegisterResult(RegisterResult::Success),
+        result
+    );
+    fake_client
+        .send(SubscriberMessage::Subscribe(Service::Color))
+        .await;
+    let result = fake_client.recv().await.unwrap();
+    assert_eq!(
+        GatewayMessage::SubscribeResult(SubscribeResult::Success),
+        result
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn test_several_clients_connect_and_register() {
+    let (listener, url) = start_tcp_stream().await;
+    let mut fake_client_1_left: FakeSubscriber =
+        FakeSubscriber::new(url.clone(), RelativeLocation::Left).await;
+    let mut fake_client_2_left: FakeSubscriber =
+        FakeSubscriber::new(url.clone(), RelativeLocation::Left).await;
+    let mut fake_client_3_center: FakeSubscriber =
+        FakeSubscriber::new(url.clone(), RelativeLocation::Center).await;
+    let mut fake_client_4_right: FakeSubscriber =
+        FakeSubscriber::new(url.clone(), RelativeLocation::Right).await;
+    let mut fake_client_5_center: FakeSubscriber =
+        FakeSubscriber::new(url.clone(), RelativeLocation::Center).await;
+    let list_fake_clients = vec![
+        fake_client_1_left,
+        fake_client_2_left,
+        fake_client_3_center,
+        fake_client_4_right,
+        fake_client_5_center,
+    ];
+    let (subtitle_service, color_service) = create_services();
+
+    tokio::spawn(start_app(subtitle_service, color_service, listener));
+    let list_fake_clients = join_all(list_fake_clients.into_iter().map(|mut client| async move {
+        client.start().await;
+        client.register().await;
+        client
+    })).await;
+
+    join_all(
+        list_fake_clients.into_iter().map(|mut client| async move{
+                let register_result = client.recv().await;
+                assert_eq!(
+                    GatewayMessage::RegisterResult(RegisterResult::Success),
+                    register_result.unwrap()
+                );
+    })).await;
+}
+
+
+#[test_log::test(tokio::test)]
+async fn test_several_clients_subscribe_to_color_different_locations_gets_different_messages() {
+    let (listener, url) = start_tcp_stream().await;
+    let mut fake_client_1_left: FakeSubscriber =
+        FakeSubscriber::new(url.clone(), RelativeLocation::Left).await;
+    let mut fake_client_2_left: FakeSubscriber =
+        FakeSubscriber::new(url.clone(), RelativeLocation::Left).await;
+    let mut fake_client_3_center: FakeSubscriber =
+        FakeSubscriber::new(url.clone(), RelativeLocation::Center).await;
+    let mut fake_client_4_right: FakeSubscriber =
+        FakeSubscriber::new(url.clone(), RelativeLocation::Right).await;
+    let mut fake_client_5_center: FakeSubscriber =
+        FakeSubscriber::new(url.clone(), RelativeLocation::Center).await;
+    let list_fake_clients = vec![
+        fake_client_1_left,
+        fake_client_2_left,
+        fake_client_3_center,
+        fake_client_4_right,
+        fake_client_5_center,
+    ];
+    let (subtitle_service, color_service) = create_services();
+    let color_service_sender = color_service.sender.clone();
+    tokio::spawn(start_app(subtitle_service, color_service, listener));
+    let list_fake_clients = join_all(list_fake_clients.into_iter().map(|mut client| async move {
+        client.start().await;
+        client.register().await;
+        client.recv().await;
+        client.send(SubscriberMessage::Subscribe(Service::Color)).await.expect("error subscribing");
+        client.recv().await;
+        client
+    })).await;
+
+    color_service_sender.send(ColorMessage::SendColor(payload::SendColor{color: Color::Red, target_location: RelativeLocation::Center})).await.expect("Error sending Color message");
+
+    let list_fake_clients = join_all(list_fake_clients.into_iter().map(|mut client| async move{
+        match client.location {
+            RelativeLocation::Center => {
+                let new_color = client.recv().await;
+                assert_eq!(
+                    GatewayMessage::Color(Color::Red),
+                    new_color.unwrap()
+                );
+            },
+            _ => {
+                let empty = client.try_recv().await;
+                assert_eq!(Err(TryRecvError::Empty), empty);    
+            }
+        }
+        client
+    })).await;
+
+    color_service_sender.send(ColorMessage::SendColor(payload::SendColor{color: Color::Blue, target_location: RelativeLocation::Right})).await.expect("Error sending Color message");
+
+    let list_fake_clients = join_all(list_fake_clients.into_iter().map(|mut client| async move{
+        match client.location {
+            RelativeLocation::Right=> {
+                let new_color = client.recv().await;
+                assert_eq!(
+                    GatewayMessage::Color(Color::Blue),
+                    new_color.unwrap()
+                );
+            },
+            _ => {
+                let empty = client.try_recv().await;
+                assert_eq!(Err(TryRecvError::Empty), empty);    
+            }
+        }
+        client
+    })).await;
+
+    color_service_sender.send(ColorMessage::SendColor(payload::SendColor{color: Color::White, target_location: RelativeLocation::Left})).await.expect("Error sending Color message");
+
+    join_all(list_fake_clients.into_iter().map(|mut client| async move{
+        match client.location {
+            RelativeLocation::Left=> {
+                let new_color = client.recv().await;
+                assert_eq!(
+                    GatewayMessage::Color(Color::White),
+                    new_color.unwrap()
+                );
+            },
+            _ => {
+                let empty = client.try_recv().await;
+                assert_eq!(Err(TryRecvError::Empty), empty);    
+            }
+        }
+    })).await;
+
+}


### PR DESCRIPTION
This ticket required several changes. Firstly, align the Color actor message processing with the subtitle actor flow. Once that was done, allowing the Subscriber to add itself to the Color actor subs.
Finally, several changes to the fake_subscriber to allow the tests to verify the messages has been targeted to the correct subscribers based on their RelativeLocation.